### PR TITLE
Transpile undici package in Next.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    transpilePackages: ['undici'],
     webpack: (config, { isServer }) => {
         if (!isServer) {
             config.resolve.fallback = {


### PR DESCRIPTION
Add `undici` to `transpilePackages` in `next.config.js` to fix build errors.

The `undici` package, a dependency of `firebase`, uses modern JavaScript syntax (e.g., private fields) that Next.js's default webpack configuration does not transpile. This caused a "Module parse failed: Unexpected token" error during the build process. Adding `undici` to `transpilePackages` ensures it is correctly transpiled, resolving the build failure.